### PR TITLE
Optimize uEMSC optimization and smaller code improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,11 @@ import pm4py
 import logging
 
 from pm4py.objects.petri_net.utils import final_marking, initial_marking
-from src.slpn_opt_uemsc_discovery import optimize_with_uemsc
-from src.slpn_visualiser import visualize_slpn, view
+from slpn_miner.src.slpn_opt_uemsc_discovery import optimize_with_uemsc
+from slpn_miner.src.slpn_visualiser import visualize_slpn, view
 from pm4py.objects.log.importer.xes import importer as xes_importer
-from util import get_slpn
-from slpn_exporter import export_slpn, export_slpn_xml
+from .util import get_slpn
+from .slpn_exporter import export_slpn, export_slpn_xml
 from pm4py.objects.petri_net.utils import check_soundness
 from pm4py.visualization.transition_system import visualizer as ts_visualizer
 
@@ -41,4 +41,4 @@ if __name__ == '__main__':
     export_slpn("../data/road/road_id0.2_uemsc.slpn", place_in_im_num, place2num, t2l, t2ip_num, t2op_num, trans_weight_dict)
 
     # export .xml format slpn
-    # export_slpn_xml("../data/road/rtf_heuristic_uemsc.pnml", pn,im, trans_weight_dict)
+    export_slpn_xml("../data/road/rtf_heuristic_uemsc.pnml", pn,im, trans_weight_dict)

--- a/main.py
+++ b/main.py
@@ -2,22 +2,23 @@ import pm4py
 import logging
 
 from pm4py.objects.petri_net.utils import final_marking, initial_marking
-from slpn_miner.src.slpn_opt_uemsc_discovery import optimize_with_uemsc
-from slpn_miner.src.slpn_visualiser import visualize_slpn, view
 from pm4py.objects.log.importer.xes import importer as xes_importer
-from .util import get_slpn
-from .slpn_exporter import export_slpn, export_slpn_xml
 from pm4py.objects.petri_net.utils import check_soundness
 from pm4py.visualization.transition_system import visualizer as ts_visualizer
+
+from src.slpn_opt_uemsc_discovery import optimize_with_uemsc
+from src.slpn_visualiser import visualize_slpn, view
+from src.util import get_slpn
+from src.slpn_exporter import export_slpn, export_slpn_xml
 
 logging.getLogger().setLevel(logging.INFO)
 
 if __name__ == '__main__':
     # import log
-    log = xes_importer.apply('../data/road/Road_Traffic_Fine_Management_Process.xes')
+    log = xes_importer.apply('data/road/road.xes')
 
     #  import petri nets
-    pn, im, fm = pm4py.read_pnml('../data/road/road_id0.2.pnml', auto_guess_final_marking=True)
+    pn, im, fm = pm4py.read_pnml('data/road/road_id0.2.pnml', auto_guess_final_marking=True)
     fm = final_marking.discover_final_marking(pn)
     im = initial_marking.discover_initial_marking(pn)
 
@@ -38,7 +39,7 @@ if __name__ == '__main__':
     view(gviz)
 
     # export .slpn formart slpn
-    export_slpn("../data/road/road_id0.2_uemsc.slpn", place_in_im_num, place2num, t2l, t2ip_num, t2op_num, trans_weight_dict)
+    export_slpn("data/road/road_id0.2_uemsc.slpn", place_in_im_num, place2num, t2l, t2ip_num, t2op_num, trans_weight_dict)
 
     # export .xml format slpn
-    export_slpn_xml("../data/road/rtf_heuristic_uemsc.pnml", pn,im, trans_weight_dict)
+    export_slpn_xml("data/road/rtf_heuristic_uemsc.pnml", pn, im, trans_weight_dict)

--- a/src/log_util.py
+++ b/src/log_util.py
@@ -38,8 +38,8 @@ def get_stochastic_language(*args, **kwargs) -> Dict[List[str], fractions.Fracti
 
         all_values_sum = sum(vars.values())
         for x in vars:
-            vars[x] = fractions.Fraction(vars[x], all_values_sum)
-            # vars[x] = vars[x] / all_values_sum
+            # vars[x] = fractions.Fraction(vars[x], all_values_sum)
+            vars[x] = vars[x] / all_values_sum
         return vars
 
 
@@ -53,8 +53,8 @@ def get_trace_weight_dict(*args, **kwargs) -> Dict[List[str], fractions.Fraction
 
         all_values_sum = sum(vars.values())
         for x in vars:
-
-            vars[x] = fractions.Fraction(vars[x], all_values_sum)
+            # vars[x] = fractions.Fraction(vars[x], all_values_sum)
+            vars[x] = vars[x] / all_values_sum
         return vars
 
 def get_variants(log: EventLog, parameters: Optional[Dict[Union[str, Parameters], Any]] = None) -> Union[

--- a/src/slpn_exporter.py
+++ b/src/slpn_exporter.py
@@ -88,10 +88,13 @@ def export_slpn_xml(output_path, petrinet, marking, trans2weight, final_marking=
         stochastic_information.set("version", "0.2")
         distribution_type = etree.SubElement(stochastic_information, "property")
         distribution_type.set("key", "distributionType")
-        distribution_type.text = "UNIFORM"
+        distribution_type.text = "IMMEDIATE"
+        training_data = etree.SubElement(stochastic_information, "property")
+        training_data.set("key", "trainingData")
+        training_data.text = ""
         distribution_parameters = etree.SubElement(stochastic_information, "property")
         distribution_parameters.set("key", "distributionParameters")
-        distribution_parameters.text = "0.0;200.0"
+        distribution_parameters.text = ""
         distribution_priority = etree.SubElement(stochastic_information, "property")
         distribution_priority.set("key", "priority")
         distribution_priority.text = "0"

--- a/src/slpn_opt_entropic_relevance_discovery.py
+++ b/src/slpn_opt_entropic_relevance_discovery.py
@@ -26,12 +26,12 @@ def optimize_with_er(log, pn, im, fm):
 
 
 def get_er_obj_func(obj2add, var_name2idx_map):
-    '''
+    """
     This is the obj func to optimize for entropic-relevance measure
     :param obj2add: each element is a list [trace_symbolic_prob, trace_real_prob]
     :param var_name2idx_map: map transition to value in var_lst
     :return: the calculated objective function for er
-    '''
+    """
 
     def er_objective_function(var_lst):
         obj_func = 0
@@ -47,13 +47,13 @@ def get_er_obj_func(obj2add, var_name2idx_map):
 
 
 def optimize_with_basin_hopping(var_lst, obj_func):
-    '''
+    """
     This function is used to optimize the objective function with basin hopping method,
     Regarding basin hopping global optimiser, refer to https://en.wikipedia.org/wiki/Basin-hopping
     :param var:
     :param obj_func:
     :return: the variable list that maximize er or uemsc-based measure
-    '''
+    """
     # add constraint such that every var is between 0 and 1
     bds = [(0.0001, 1) for i in range(len(var_lst))]
     # define the method and bound

--- a/src/slpn_opt_entropic_relevance_discovery.py
+++ b/src/slpn_opt_entropic_relevance_discovery.py
@@ -4,11 +4,12 @@ import sys
 import pm4py
 import scipy
 
-from src.slpn_visualiser import visualize_slpn, view
-from symbolic_conversion import calculate_inverse_poland_expression, get_inverse_poland_expression
 from pm4py.objects.log.importer.xes import importer as xes_importer
-from util import setup, get_slpn
-from slpn_exporter import export_slpn, export_slpn_xml
+
+from src.slpn_visualiser import visualize_slpn, view
+from src.symbolic_conversion import calculate_inverse_poland_expression, get_inverse_poland_expression
+from src.util import setup, get_slpn
+from src.slpn_exporter import export_slpn, export_slpn_xml
 
 
 def optimize_with_er(log, pn, im, fm):

--- a/src/slpn_opt_uemsc_discovery.py
+++ b/src/slpn_opt_uemsc_discovery.py
@@ -2,11 +2,12 @@ import pm4py
 import scipy
 
 from pm4py.objects.petri_net.utils import final_marking, initial_marking
-from src.slpn_visualiser import visualize_slpn, view
-from symbolic_conversion import calculate_inverse_poland_expression, get_inverse_poland_expression
 from pm4py.objects.log.importer.xes import importer as xes_importer
-from util import setup, get_slpn
-from slpn_exporter import export_slpn, export_slpn_xml
+
+from src.slpn_visualiser import visualize_slpn, view
+from src.symbolic_conversion import calculate_inverse_poland_expression, get_inverse_poland_expression
+from src.util import setup, get_slpn
+from src.slpn_exporter import export_slpn, export_slpn_xml
 
 
 def optimize_with_uemsc(log, pn, im, fm):

--- a/src/slpn_opt_uemsc_discovery.py
+++ b/src/slpn_opt_uemsc_discovery.py
@@ -26,13 +26,13 @@ def optimize_with_uemsc(log, pn, im, fm):
 
 
 def optimize_with_basin_hopping(var_lst, obj_func):
-    '''
+    """
     This function is used to optimize the objective function with basin hopping method,
     Regarding basin hopping global optimiser, refer to https://en.wikipedia.org/wiki/Basin-hopping
     :param var:
     :param obj_func:
     :return: the variable list that maximize er or uemsc-based measure
-    '''
+    """
     # add constraint such that every var is between 0 and 1
     bds = [(0.0001, 1) for i in range(len(var_lst))]
     # define the method and bound
@@ -56,12 +56,12 @@ def uemsc_objective_function(inverse_poland_exprs, trace_probs, constants_lookup
 
 
 def get_uemsc_obj_func(obj2add, var_name2idx_map):
-    '''
+    """
     This is the obj func to optimize for unit-Earth Mover's Stochastic Conformance (uEMSC) measure
     :param obj2add: each element is a list [trace_symbolic_prob, trace_real_prob]
     :param var_name2idx_map: map transition to value in var_lst
     :return: the calculated objective function for uEMSC
-    '''
+    """
     inverse_obj2add = [
         (get_inverse_poland_expression(trace_symbolic_prob), trace_real_prob)
         for trace_symbolic_prob, trace_real_prob in obj2add

--- a/src/stochastic_cross_product.py
+++ b/src/stochastic_cross_product.py
@@ -3,10 +3,9 @@
 import copy
 import logging
 import re
-import stochastic_transition_system
 
-from stochastic_equation_system import get_equation_system, expand_powers
-from stochastic_transition_system import StochasticTransitionSystem
+from src.stochastic_equation_system import get_equation_system, expand_powers
+from src.stochastic_transition_system import StochasticTransitionSystem
 
 logging.getLogger().setLevel(logging.DEBUG)
 
@@ -343,7 +342,7 @@ class ConstructCP:
         :param original_t_name:
         :param new_t_name:
         """
-        tran = stochastic_transition_system.StochasticTransitionSystem.Transition(
+        tran = StochasticTransitionSystem.Transition(
             str(new_t_name),
             original_t_name,
             t_label,

--- a/src/stochastic_cross_product.py
+++ b/src/stochastic_cross_product.py
@@ -13,13 +13,13 @@ logging.getLogger().setLevel(logging.DEBUG)
 def set_and_get_initial_state(trace_incoming_transitions,
                               srg_incoming_transitions
                               ):
-    '''
+    """
 
     :param trace_incoming_transitions:
     :param srg_incoming_transitions:
     :param cross_product:
     :return: the initial states in trace and srg
-    '''
+    """
     for s1 in trace_incoming_transitions:
         if trace_incoming_transitions[s1] is None:
             for s2 in srg_incoming_transitions:
@@ -39,14 +39,14 @@ class ConstructCP:
                           trace_outgoing_transitions,
                           srg_incoming_transitions,
                           srg_outgoing_transitions):
-        '''
+        """
 
         :param trace_incoming_transitions:
         :param trace_outgoing_transitions:
         :param srg_incoming_transitions:
         :param srg_outgoing_transitions:
         :return: a cross product as a stochastic transition system between trace and srg
-        '''
+        """
         self.cross_product.connected_states = set()
         self.boundary_states_in_rsg = dict()
         self.cross_product = StochasticTransitionSystem()
@@ -159,28 +159,28 @@ class ConstructCP:
                 return transition.transition_prob
 
     def connected(self, initial_state, final_state):
-        '''
+        """
         :return: update cross product
-        '''
+        """
         self.cross_product.connected_states = self.connected_to_initial_state_set & self.connected_to_final_state_set
         self.cross_product.connected_states.add(initial_state)
         self.cross_product.connected_states.add(final_state)
 
     def connected_to_initial_state(self, state_to_explore):
-        '''
+        """
 
         :return: update cross product
-        '''
+        """
         for transition in self.cross_product.transitions:
             if transition.from_state == state_to_explore:
                 self.connected_to_initial_state_set.add(transition.to_state)
                 self.connected_to_initial_state(transition.to_state)
 
     def connected_to_final_state(self, state_to_explore):
-        '''
+        """
 
         :return: update cross product
-        '''
+        """
         for transition in self.cross_product.transitions:
             if transition.to_state == state_to_explore:
                 self.connected_to_final_state_set.add(transition.from_state)
@@ -193,7 +193,7 @@ class ConstructCP:
                          srg_outgoing_transitions,
                          srg_current_state,
                          ):
-        '''
+        """
 
         :param trace_outgoing_transitions:
         :param trace_transition_label:
@@ -202,7 +202,7 @@ class ConstructCP:
         :param srg_current_state:
         :param non_silent_tansition_num: count the time we observe non-silent transitions
         :return: no return
-        '''
+        """
         state_name = str(trace_current_state) + str(srg_current_state)
 
         # iterate until find the matching state with same transition_label

--- a/src/stochastic_equation_system.py
+++ b/src/stochastic_equation_system.py
@@ -6,13 +6,13 @@ from sympy import Eq, solve, Symbol
 logging.getLogger().setLevel(logging.DEBUG)
 
 def get_equation_system(cross_product, initial_state, final_state):
-    '''
+    """
     This function generates the equation system for the stochastic cross product.
     :param cross_product:
     :param initial_state:
     :param final_state:
     :return: the symbolic representation of trace probability from the slpn
-    '''
+    """
     eqs = []
     variables = []
     state_to_variable_map = {}
@@ -54,11 +54,11 @@ def get_equation_system(cross_product, initial_state, final_state):
 
 
 def expand_powers(s):
-    '''
+    """
     This function expands the powers in the string.
     :param s:
     :return:
-    '''
+    """
     # Function to replace match with expanded form
     def replacer(match):
         var = match.group(1)

--- a/src/stochastic_reachability_graph.py
+++ b/src/stochastic_reachability_graph.py
@@ -6,7 +6,7 @@ from pm4py.objects.petri_net.utils import align_utils
 from pm4py.objects.transition_system import obj as ts
 from pm4py.util import exec_utils
 
-import stochastic_transition_system
+from src.stochastic_transition_system import StochasticTransitionSystem
 
 
 class Parameters(Enum):
@@ -85,7 +85,7 @@ def construct_stochatic_reachability_graph_from_flow(incoming_transitions, outgo
     if parameters is None:
         parameters = {}
 
-    re_gr = stochastic_transition_system.StochasticTransitionSystem()
+    re_gr = StochasticTransitionSystem()
     map_states = {}
 
     for s in incoming_transitions:
@@ -148,7 +148,7 @@ def construct_srg(incoming_transitions, outgoing_transitions, parameters=None):
     if parameters is None:
         parameters = {}
 
-    re_gr = stochastic_transition_system.StochasticTransitionSystem()
+    re_gr = StochasticTransitionSystem()
 
     map_states = {}
     srg_incoming_transitions = {}
@@ -202,8 +202,8 @@ def add_arc_from_to(new_t_id, original_t_id, t_label, t_prob, fr, to, stochastic
     -------
     None
     """
-    tran = stochastic_transition_system.StochasticTransitionSystem.Transition("t" + str(new_t_id), original_t_id,
-                                                                              t_label, t_prob, fr, to, data)
+    tran = StochasticTransitionSystem.Transition("t" + str(new_t_id), original_t_id,
+                                                 t_label, t_prob, fr, to, data)
     stochastic_ts.transitions.add(tran)
 
     fr.outgoing.add(tran)

--- a/src/symbolic_conversion.py
+++ b/src/symbolic_conversion.py
@@ -2,7 +2,7 @@ def calculate_inverse_poland_expression(inverse_poland_expression, str_to_idx, v
     result = 0
     calculate_stack = []
     for str_val in inverse_poland_expression:
-        if str_val in ['+', '-', '*', '/']:
+        if str_val in {'+', '-', '*', '/'}:
             # Do the calculation for two variables.
             p1 = calculate_stack.pop()
             p2 = calculate_stack.pop()
@@ -58,7 +58,7 @@ def get_inverse_poland_expression(exp):
                 num += exp[i]
                 i += 1
             reverse_polish.append(num)
-        elif exp[i] in ['+', '-', '*', '/', '(', ')']:
+        elif exp[i] in {'+', '-', '*', '/', '(', ')'}:
             op = exp[i]
             if op == '(':
                 operator.append(op)
@@ -66,14 +66,14 @@ def get_inverse_poland_expression(exp):
                 while operator[-1] != '(':
                     reverse_polish.append(operator.pop())
                 operator.pop()
-            elif op in ['+', '-']:
+            elif op in {'+', '-'}:
                 if operator[-1] == '(':
                     operator.append(op)
                 else:
                     while operator[-1] != '#' and operator[-1] != '(':
                         reverse_polish.append(operator.pop())
                     operator.append(op)
-            elif op in ['*', '/']:
+            elif op in {'*', '/'}:
                 if operator[-1] == '(':
                     operator.append(op)
                 else:

--- a/src/symbolic_conversion.py
+++ b/src/symbolic_conversion.py
@@ -1,3 +1,52 @@
+import numba
+import numpy as np
+
+
+plus_idx = -1
+minus_idx = -2
+prod_idx = -3
+div_idx = -4
+
+
+@numba.njit("float64(int16[::1], float64[::1], float64[::1])", inline='always', cache=True)
+def calculate_inverse_poland_expression_numba(inverse_poland_expression, constants_dict, var_lst):
+    calculate_stack = np.zeros(len(inverse_poland_expression), dtype=np.float64) # preallocate the stack
+    stack_ptr = int(0)
+    len_var_lst = len(var_lst)
+
+    for idx in inverse_poland_expression:
+        if idx == plus_idx:
+            p2 = calculate_stack[stack_ptr - 2]
+            p1 = calculate_stack[stack_ptr - 1]
+            calculate_stack[stack_ptr - 2] = p2 + p1
+            stack_ptr -= 1
+        elif idx == minus_idx:
+            p2 = calculate_stack[stack_ptr - 2]
+            p1 = calculate_stack[stack_ptr - 1]
+            calculate_stack[stack_ptr - 2] = p2 - p1
+            stack_ptr -= 1
+        elif idx == prod_idx:
+            p2 = calculate_stack[stack_ptr - 2]
+            p1 = calculate_stack[stack_ptr - 1]
+            calculate_stack[stack_ptr - 2] = p2 * p1
+            stack_ptr -= 1
+        elif idx == div_idx:
+            p2 = calculate_stack[stack_ptr - 2]
+            p1 = calculate_stack[stack_ptr - 1]
+            calculate_stack[stack_ptr - 2] = p2 / p1
+            stack_ptr -= 1
+        else:
+            if idx < len_var_lst:
+                val = var_lst[idx]
+                calculate_stack[stack_ptr] = val
+            else:
+                constant_idx = idx - len_var_lst
+                calculate_stack[stack_ptr] = constants_dict[constant_idx]
+            stack_ptr += 1
+
+    return calculate_stack[0]
+
+
 def calculate_inverse_poland_expression(inverse_poland_expression, str_to_idx, var_lst):
     result = 0
     calculate_stack = []

--- a/src/util.py
+++ b/src/util.py
@@ -48,10 +48,10 @@ def setup(log, pn, im, fm):
 
     covered_trace = sum(float(sublist[1]) for sublist in obj2add)
     if len(obj2add) == 0:
-        logging.warning("No traces fit the model, the stochastic discovery will fail. Please check the log and the "
-                        "model.")
+        logging.warning("No traces fit the model, the stochastic discovery will fail. "
+                        "Please check the log and the model.")
     else:
-        logging.info("The stochastic discovery covers {:.2%} of the traces from the log.".format(covered_trace))
+        logging.info(f"The stochastic discovery covers {covered_trace:.2f} of the traces from the log.")
 
     return obj2add, var_name2idx_map, var_idx2name_map, var_lst
 

--- a/src/util.py
+++ b/src/util.py
@@ -14,7 +14,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 def setup(log, pn, im, fm):
     # get trace and its probability
-    trace_prob_dict = get_stochastic_language(log)
+    stochastic_lang = get_stochastic_language(log)
 
     # get the log variants
     variants = variants_filter.get_variants(log)
@@ -45,23 +45,18 @@ def setup(log, pn, im, fm):
     obj2add = []
 
     # iterate each trace
-    for trace, weight in trace_prob_dict.items():
-        for i in range(len(log_variants)):
-            if trace == tuple(event['concept:name'] for event in log_variants[i]):
-                # get trace probability
-                weight_result = float(weight)
-                # get trace incoming and outgoing transitions
-                trace_ot, trace_it = create_dfa_from_list([event['concept:name'] for event in log_variants[i]])
-                CP = ConstructCP()
-                symbolic_trace_prob = CP.get_cross_product(trace_it,
-                                                           trace_ot,
-                                                           srg_it,
-                                                           srg_ot)
-                if symbolic_trace_prob == "0":
-                    break
-                sub_obj = [symbolic_trace_prob, weight_result]
-                obj2add.append(sub_obj)
-                break
+    for trace, weight in stochastic_lang.items():
+        # get trace probability
+        weight_result = float(weight)
+        # get trace incoming and outgoing transitions
+        trace_ot, trace_it = create_dfa_from_list(trace)
+        CP = ConstructCP()
+        symbolic_trace_prob = CP.get_cross_product(trace_it, trace_ot, srg_it, srg_ot)
+        if symbolic_trace_prob == "0":
+            continue
+        sub_obj = [symbolic_trace_prob, weight_result]
+        obj2add.append(sub_obj)
+
     covered_trace = sum(float(sublist[1]) for sublist in obj2add)
     if len(obj2add) == 0:
         logging.warning("No traces fit the model, the stochastic discovery will fail. Please check the log and the "

--- a/src/util.py
+++ b/src/util.py
@@ -16,17 +16,6 @@ def setup(log, pn, im, fm):
     # get trace and its probability
     stochastic_lang = get_stochastic_language(log)
 
-    # get the log variants
-    variants = variants_filter.get_variants(log)
-    log_variants = EventLog()
-    for variant, traces in variants.items():
-        for trace in traces:
-            new_trace = Trace()
-            for event in trace:
-                new_trace.append(event)
-            log_variants.append(new_trace)
-            break
-
     # get the transition to weight mapping
     var_name2idx_map = {}
     var_idx2name_map = {}
@@ -63,6 +52,7 @@ def setup(log, pn, im, fm):
                         "model.")
     else:
         logging.info("The stochastic discovery covers {:.2%} of the traces from the log.".format(covered_trace))
+
     return obj2add, var_name2idx_map, var_idx2name_map, var_lst
 
 

--- a/src/util.py
+++ b/src/util.py
@@ -1,14 +1,14 @@
 import re
 import logging
 
-from pm4py.algo.conformance.alignments.petri_net import algorithm as alignments
 from pm4py.objects.log.obj import EventLog, Trace
-from src.log_util import get_stochastic_language
-from stochastic_cross_product import ConstructCP
-from slang_importer import parse_slang_file
-from stochastic_reachability_graph import construct_stochastic_reachability_graph
-from trace_dfa import create_dfa_from_list
 from pm4py.algo.filtering.log.variants import variants_filter
+
+from src.log_util import get_stochastic_language
+from src.stochastic_cross_product import ConstructCP
+from src.stochastic_reachability_graph import construct_stochastic_reachability_graph
+from src.trace_dfa import create_dfa_from_list
+
 
 logging.getLogger().setLevel(logging.DEBUG)
 


### PR DESCRIPTION
This PR implements a few code quality improvements

We also use numba to significantly speed up the uEMSC code (depending on the log, by over an order of magnitude)

The changes are organized in self-contained commits. The most important part is naturally the one containing the numba stuff. It's not too difficult, though. We just have to pull some tricks to ensure that the compilation works effectively

I believe that a similar trick can be pulled to optimize the entropic relevance code too. But I didn't have the time